### PR TITLE
Update Grafbase Gateway

### DIFF
--- a/gateways/grafbase/install.sh
+++ b/gateways/grafbase/install.sh
@@ -5,13 +5,12 @@ set -euo pipefail
 # to the current directory instead of /usr/local/bin
 
 # https://github.com/grafbase/grafbase/releases
-VERSION="0.48.1"
+VERSION="0.49.0"
 
 error() {
     echo -e "${Red}error${Color_Off}:" "$@" >&2
     exit 1
 }
-
 
 case $(uname -ms) in
 'Darwin x86_64')
@@ -49,6 +48,5 @@ curl --fail --location --progress-bar --output "$exe" "$gateway_uri" ||
 
 chmod +x "$exe" ||
     error 'Failed to set permissions on grafbase gateway executable'
-
 
 echo "success"


### PR DESCRIPTION
The 0.48.1 didn't have inflight request deduplication, so we added it in the 0.49.0 to have an apples to apples comparison.